### PR TITLE
Updates for VMware Workstation 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@
 #
 
 KERNEL := $(KERNELRELEASE)
-HEADERS := /usr/src/linux-$(KERNEL)/include
+HEADERS := /usr/src/linux-headers-$(KERNEL)/include
 GCC := $(shell vmware-modconfig --console --get-gcc)
 DEST := /lib/modules/$(KERNEL)/vmware
 
-TARGETS := vmmon vmnet vmblock vmci vsock
+TARGETS := vmmon vmnet
 
 LOCAL_MODULES := $(addsuffix .ko, $(TARGETS))
 
@@ -33,10 +33,7 @@ all: $(LOCAL_MODULES)
 	rm -rf $(DEST)
 	depmod
 
-/usr/src/linux-$(KERNEL)/include/linux/version.h:
-	ln -s /usr/src/linux-$(KERNEL)/include/generated/uapi/linux/version.h /usr/src/linux-$(KERNEL)/include/linux/version.h
-
-%.ko: /usr/src/linux-$(KERNEL)/include/linux/version.h
+%.ko:
 	vmware-modconfig --console --build-mod -k $(KERNEL) $* $(GCC) $(HEADERS) vmware/
 	cp -f $(DEST)/$*.ko .
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #
 
 KERNEL := $(KERNELRELEASE)
-HEADERS := /usr/src/linux-headers-$(KERNEL)/include
+HEADERS := $(shell vmware-modconfig --console --get-kernel-headers -k $(KERNEL))
 GCC := $(shell vmware-modconfig --console --get-gcc)
 DEST := /lib/modules/$(KERNEL)/vmware
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The wrapper requires DKMS (normally available through your distribution package
 manager) and an installation of VMware Workstation.
 
 # Installation
-Clone the repository to (or copy its content to) /usr/src/vmware-modules-9.
+Clone the repository to (or copy its content to) /usr/src/vmware-modules-15.
 Then, as root, declare and setup the module in DKMS using the following command:
 
 ```
-# dkms install vmware-modules/9 -k $(uname -r)
+# dkms install vmware-modules/15 -k $(uname -r)
 ```

--- a/dkms.conf
+++ b/dkms.conf
@@ -16,7 +16,7 @@
 
 # Declare package
 PACKAGE_NAME="vmware-modules"
-PACKAGE_VERSION="9"
+PACKAGE_VERSION="15"
 
 # How to create our modules
 MAKE[0]="make all"
@@ -29,20 +29,8 @@ BUILT_MODULE_LOCATION[0]="modules"
 BUILT_MODULE_NAME[1]="vmnet"
 BUILT_MODULE_LOCATION[1]="modules"
 
-BUILT_MODULE_NAME[2]="vmblock"
-BUILT_MODULE_LOCATION[2]="modules"
-
-BUILT_MODULE_NAME[3]="vmci"
-BUILT_MODULE_LOCATION[3]="modules"
-
-BUILT_MODULE_NAME[4]="vsock"
-BUILT_MODULE_LOCATION[4]="modules"
-
 DEST_MODULE_LOCATION[0]="/extra/vmware"
 DEST_MODULE_LOCATION[1]="/extra/vmware"
-DEST_MODULE_LOCATION[2]="/extra/vmware"
-DEST_MODULE_LOCATION[3]="/extra/vmware"
-DEST_MODULE_LOCATION[4]="/extra/vmware"
 
 AUTOINSTALL="yes"
 


### PR DESCRIPTION
I've updated the module to support VMware Workstation 15. The file paths are for an Ubuntu 18.10 system running the 4.18.0-12-generic kernel.

On a side note, is there a reason DKMS isn't configured by the VMware Workstation installer? As it is stands currently, updating the kernel on a Linux system breaks VMware Workstation and the modules won't work at all if secure boot is enabled. Using DKMS for module management solves both of these issues. I can imagine this will be a frequent support request as setups with secure boot enabled become increasingly common.